### PR TITLE
Add FIM Agent to MCP Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@
 - [3choff/mcp-chatbot](https://github.com/3choff/mcp-chatbot) — CLI chatbot with MCP integration demo ☆`246`
 - [johannesbrandenburger/typst-mcp](https://github.com/johannesbrandenburger/typst-mcp) — MCP server for Typst markup-based typesetting system ☆`121`
 - [tanaikech/ToolsForMCPServer](https://github.com/tanaikech/ToolsForMCPServer) — MCP server built with Google Apps Script for Gemini CLI ☆`97`
+- [fim-ai/fim-agent](https://github.com/fim-ai/fim-agent) — AI-powered Connector Hub with MCP tool auto-discovery for ReAct and DAG execution modes ☆`85`
 - [xzq-xu/jvm-mcp-server](https://github.com/xzq-xu/jvm-mcp-server) — JVM-based MCP server implementation ☆`76`
 - [ckanthony/gin-mcp](https://github.com/ckanthony/gin-mcp) — Enable MCP features for any Gin API with a line of code ☆`70`
 - [php-mcp/client](https://github.com/php-mcp/client) — Core PHP implementation for the Model Context Protocol (MCP) Client ☆`54`


### PR DESCRIPTION
## Add FIM Agent to MCP Clients

[FIM Agent](https://github.com/fim-ai/fim-agent) is an AI-powered Connector Hub that uses MCP servers as one of three tool integration methods (built-in tools, connector tools, and MCP tools).

**MCP features:**
- Auto-discovery and registration of MCP tools into the agent's tool registry
- Available in both ReAct and DAG planning execution modes
- Admin-provisioned global MCP servers loaded in all chat sessions
- Per-user MCP server configuration

**Links:** [GitHub](https://github.com/fim-ai/fim-agent) | [Website](https://agent.fim.ai) | [Docs](https://docs.fim.ai)