### PR TITLE
Add Xquik MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1592,6 +1592,7 @@
 - [34892002/bilibili-mcp-js](https://github.com/34892002/bilibili-mcp-js) — Bilibili video search MCP service ☆`151`
 - [Seym0n/tiktok-mcp](https://github.com/Seym0n/tiktok-mcp) — Model Context Protocol (MCP) with TikTok integration ☆`135`
 - [trypeggy/instagram_dm_mcp](https://github.com/trypeggy/instagram_dm_mcp) — Instagram Direct messages MCP ☆`152`
+- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) — X (Twitter) MCP server with 20 tools for tweet search, user lookup, follower extraction, engagement metrics & write actions ☆`0`
 - [HagaiHen/facebook-mcp-server](https://github.com/HagaiHen/facebook-mcp-server) — Facebook posts, comments, insights automation ☆`118`
 - [king-of-the-grackles/reddit-research-mcp](https://github.com/king-of-the-grackles/reddit-research-mcp) — Reddit research with structured insights ☆`91`
 - [anwerj/youtube-uploader-mcp](https://github.com/anwerj/youtube-uploader-mcp) — Upload/Schedule videos on Youtube with the help of AI ☆`37`

--- a/README.md
+++ b/README.md
@@ -1592,7 +1592,6 @@
 - [34892002/bilibili-mcp-js](https://github.com/34892002/bilibili-mcp-js) — Bilibili video search MCP service ☆`151`
 - [Seym0n/tiktok-mcp](https://github.com/Seym0n/tiktok-mcp) — Model Context Protocol (MCP) with TikTok integration ☆`135`
 - [trypeggy/instagram_dm_mcp](https://github.com/trypeggy/instagram_dm_mcp) — Instagram Direct messages MCP ☆`152`
-- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) — X (Twitter) MCP server with 20 tools for tweet search, user lookup, follower extraction, engagement metrics & write actions ☆`0`
 - [HagaiHen/facebook-mcp-server](https://github.com/HagaiHen/facebook-mcp-server) — Facebook posts, comments, insights automation ☆`118`
 - [king-of-the-grackles/reddit-research-mcp](https://github.com/king-of-the-grackles/reddit-research-mcp) — Reddit research with structured insights ☆`91`
 - [anwerj/youtube-uploader-mcp](https://github.com/anwerj/youtube-uploader-mcp) — Upload/Schedule videos on Youtube with the help of AI ☆`37`

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -3041,6 +3041,8 @@ categories:
         description: Bridge Substack writings to Claude
       - url: https://github.com/34892002/bilibili-mcp-js
         description: Bilibili video search MCP service
+      - url: https://github.com/Xquik-dev/x-twitter-scraper
+        description: X API integration with 40+ tools, webhooks & MCP server
   - name: Sports
     repos:
       - url: https://github.com/guillochon/mlb-api-mcp


### PR DESCRIPTION
## Summary

- Adds [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to the Social Media section
- X (Twitter) MCP server with 20 tools for tweet search, user lookup, follower extraction, engagement metrics & write actions
- Remote MCP endpoint: https://xquik.com/mcp (StreamableHTTP, API key auth)
- Docs: https://docs.xquik.com