### PR TITLE
Add onUI - UI Annotation MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@
 - [kontext-dev/browser-use-mcp-server](https://github.com/kontext-dev/browser-use-mcp-server) — Browse the web, directly from Cursor etc. ☆`812`
 - [ndthanhdev/mcp-browser-kit](https://github.com/ndthanhdev/mcp-browser-kit) — AI assistants interact with local browser ☆`51`
 - [BB-fat/browser-use-rs](https://github.com/BB-fat/browser-use-rs) — Rust-based browser automation MCP server ☆`31`
-- [onllm-dev/onUI](https://github.com/onllm-dev/onUI) — Browser extension and MCP server for annotation-first UI pair programming with AI agents ☆`18`
 ### Cloud Services
 
 - [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) — Browser control with Browserbase ☆`3,189`

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@
 - [kontext-dev/browser-use-mcp-server](https://github.com/kontext-dev/browser-use-mcp-server) — Browse the web, directly from Cursor etc. ☆`812`
 - [ndthanhdev/mcp-browser-kit](https://github.com/ndthanhdev/mcp-browser-kit) — AI assistants interact with local browser ☆`51`
 - [BB-fat/browser-use-rs](https://github.com/BB-fat/browser-use-rs) — Rust-based browser automation MCP server ☆`31`
+- [onllm-dev/onUI](https://github.com/onllm-dev/onUI) — Browser extension and MCP server for annotation-first UI pair programming with AI agents ☆`18`
 ### Cloud Services
 
 - [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) — Browser control with Browserbase ☆`3,189`

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -312,6 +312,8 @@ categories:
           - url: https://github.com/mattiasw/browserloop
           - url: https://github.com/yetidevworks/yetibrowser-mcp
           - url: https://github.com/vincent-pli/chrome-history-mcp
+          - url: https://github.com/onllm-dev/onUI
+            description: Browser extension and MCP server for annotation-first UI pair programming with AI agents
       - name: Cloud Services
         repos:
           - url: https://github.com/browserbase/mcp-server-browserbase


### PR DESCRIPTION
## Summary

- Adds [onUI](https://github.com/onllm-dev/onUI) to the Browser Tools section under Browser Automation
- onUI is a browser extension and MCP server for annotation-first UI pair programming with AI agents
- Built with TypeScript, runs locally

## Entry added

```
- [onllm-dev/onUI](https://github.com/onllm-dev/onUI) — Browser extension and MCP server for annotation-first UI pair programming with AI agents
```