### PR TITLE
Add hashgraph-online/hashnet-mcp to Platforms & Registries

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -265,6 +265,8 @@ categories:
             description: Universal AI platform with MCP and multi-provider support
           - url: https://github.com/wegotdocs/open-mcp
             description: Open standard and registry for converting web APIs into MCP servers
+          - url: https://github.com/hashgraph-online/hashnet-mcp
+            description: Official MCP server for the Hashgraph Online agent registry - agent discovery, registration, encrypted P2P communication
           - url: https://github.com/Data-Everything/mcp-server-templates
           - url: https://github.com/mintmcp/servers
           - url: https://github.com/VeyraX/veyrax-mcp


### PR DESCRIPTION
Adds hashgraph-online/hashnet-mcp — Official MCP server for the Hashgraph Online agent registry

- Agent discovery and registration
- Encrypted P2P communication between agents
- Bridges to ERC-8004, A2A, Virtuals, x402
- 187K+ verified agents