### PR TITLE
Add BGPT MCP to Academic Research category

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2719,6 +2719,8 @@ categories:
           - url: https://github.com/QuentinCody/datacite-mcp-server
           - url: https://github.com/kaliaboi/mcp-zotero
             description: Zotero collections for Claude Desktop
+          - url: https://github.com/connerlambden/bgpt-mcp
+            description: Search scientific papers with structured experimental data from full-text studies
       - name: Data APIs
         repos:
           - url: https://github.com/0xDAEF0F/job-searchoor


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) to the **Search & Extraction > Academic Research** subcategory in `repositories.yaml`.

BGPT MCP is a remote MCP server for searching scientific papers with structured experimental data extracted from full-text studies.

- SSE + Streamable HTTP endpoints
- Tool: `search_papers` — returns 25+ structured fields per paper
- npm: `npx bgpt-mcp`

Made with [Cursor](https://cursor.com)