### PR TITLE
Add Global Chat — cross-protocol AI agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 - [matthewdcage/cursor-mcp-installer](https://github.com/matthewdcage/cursor-mcp-installer) — Install MCPs in Cursor from git URL ☆`75`
 - [useparagon/paragon-mcp](https://github.com/useparagon/paragon-mcp) — Access 130+ SaaS integrations via ActionKit ☆`46`
 - [VeyraX/veyrax-mcp](https://github.com/VeyraX/veyrax-mcp) — VeyraX unified tool access via single MCP ☆`48`
+- [pumanitro/global-chat](https://github.com/pumanitro/global-chat) — Cross-protocol AI agent discovery across MCP, A2A, agents.txt, and 12+ registries ☆`0`
 ## Browser Automation
 
 ### AI Automation


### PR DESCRIPTION
## What

Adds [Global Chat](https://github.com/pumanitro/global-chat) to the **Platforms & Registries** section.

## About the project

Global Chat is a cross-protocol AI agent discovery platform with an MCP server (`@global-chat/mcp-server` on npm). It aggregates agents across MCP, A2A, agents.txt, ACDP, and 12+ other protocols into a single searchable directory of 100K+ agents across 15+ registries. It also includes a free agents.txt validator/linter.

- **npm**: `@global-chat/mcp-server`
- **Website**: https://global-chat.io
- **GitHub**: https://github.com/pumanitro/global-chat