### PR TITLE
Add Not Human Search to Web Search Engines

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2882,6 +2882,8 @@ categories:
           - url: https://github.com/surabhya/SafetySearch
           - url: https://github.com/Cloudsway-AI/smartsearch
           - url: https://github.com/longyi1207/glean-mcp-server
+          - url: https://github.com/unitedideas/nothumansearch
+            description: Search engine for AI agents with 300+ tools ranked by agentic readiness
   - name: Security
     subcategories:
       - name: Identity & Access


### PR DESCRIPTION
## Summary

- Adds [Not Human Search](https://nothumansearch.ai) to the **Search & Extraction > Web Search Engines** subcategory
- Not Human Search is a search engine built for AI agents that indexes 300+ tools ranked by agentic readiness
- Features: MCP server (`/.well-known/mcp.json`), REST API (`/api/v1/search`, `/api/v1/site/{domain}`, `/api/v1/submit`, `/api/v1/stats`), full-text search, agent-first filtering

## Repo

- GitHub: https://github.com/unitedideas/nothumansearch
- Live: https://nothumansearch.ai