### PR TITLE
Add Qartez - semantic code intelligence MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@
 - [micl2e2/code-to-tree](https://github.com/micl2e2/code-to-tree) — Source code to AST tree conversion ☆`82`
 - [codacy/codacy-mcp-server](https://github.com/codacy/codacy-mcp-server) — Codacy's MCP Server implementation ☆`56`
 - [CodeLogicIncEngineering/codelogic-mcp-server](https://github.com/CodeLogicIncEngineering/codelogic-mcp-server) — Codelogic software dependency analysis ☆`36`
+- [kuberstar/qartez-mcp](https://github.com/kuberstar/qartez-mcp) — Semantic code intelligence with 27 tools for project maps, symbol search, impact analysis, call hierarchies, architecture boundaries, and safe refactoring. Built in Rust. ☆`35`
 - [azer/react-analyzer-mcp](https://github.com/azer/react-analyzer-mcp) — React code analysis and docs generation ☆`57`
 - [cqfn/aibolit-mcp-server](https://github.com/cqfn/aibolit-mcp-server) — Aibolit Java static analyzer for AI agents ☆`25`
 - [PromptExecution/rust-cargo-docs-rag-mcp](https://github.com/PromptExecution/rust-cargo-docs-rag-mcp) — MCP tools for Rust Context Engineering (rustdocs, rust analyzer) ☆`17`


### PR DESCRIPTION
## Add Qartez MCP Server

[Qartez](https://github.com/kuberstar/qartez-mcp) is a semantic code intelligence MCP server built in Rust with 27 tools for code exploration and refactoring.

**Key capabilities:**
- Project maps and symbol search
- Impact analysis and call hierarchies
- Architecture boundary enforcement
- Clone detection and dead code analysis
- Safe refactoring (rename, move)

**Links:**
- GitHub: https://github.com/kuberstar/qartez-mcp
- Website: https://qartez.dev

Added to the **Code Analysis** section.