### PR TITLE
Add EnigmAgent — AES-256-GCM encrypted vault MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,6 +1551,7 @@
 - [AIM-Intelligence/AIM-MCP](https://github.com/AIM-Intelligence/AIM-MCP) — AIM MCP Server :: Guard and Protect your MCPs & AI Chatting ☆`20`
 - [cromwellian/hippycampus](https://github.com/cromwellian/hippycampus) — REST endpoint to MCP conversion ☆`20`
 - [kontext-security/attestable-mcp-server](https://github.com/kontext-security/attestable-mcp-server) — Hardware attestation for MCP server integrity ☆`18`
+- [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) — AES-256-GCM + Argon2id encrypted local vault for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context ☆`1`
 ### Network & Firewall
 
 - [vespo92/OPNSenseMCP](https://github.com/vespo92/OPNSenseMCP) — MCP Server for OPNSense to act as IaC proxy ☆`45`


### PR DESCRIPTION
## EnigmAgent — Encrypted Local Vault for AI Agent Credentials

**Repository:** https://github.com/Agnuxo1/EnigmAgent
**npm:** `enigmagent-mcp` (v1.0.0)
**Category:** Security → MCP Security

### Why it fits MCP Security

EnigmAgent prevents credential leaks in LLM contexts:

- **AES-256-GCM** authenticated encryption (prevents ciphertext tampering)  
- **Argon2id** key derivation (memory-hard, resists GPU/ASIC brute-force)  
- **`{{PLACEHOLDER}}` resolution** — API keys injected at runtime, LLM never sees actual values  
- **Domain binding** — secrets scoped to specific calling origins  
- **Zero-knowledge** — master password never stored, vault key derived on unlock  
- **Local-only** — no cloud sync, no telemetry  

Works as both MCP server (stdio) and REST API (port 3737). Compatible with Claude Desktop, n8n, Cursor, and all MCP clients.