### PR TITLE
Add enigmagent-mcp — encrypted local vault MCP server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,7 +1551,6 @@
 - [AIM-Intelligence/AIM-MCP](https://github.com/AIM-Intelligence/AIM-MCP) — AIM MCP Server :: Guard and Protect your MCPs & AI Chatting ☆`20`
 - [cromwellian/hippycampus](https://github.com/cromwellian/hippycampus) — REST endpoint to MCP conversion ☆`20`
 - [kontext-security/attestable-mcp-server](https://github.com/kontext-security/attestable-mcp-server) — Hardware attestation for MCP server integrity ☆`18`
-- [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) — AES-256-GCM + Argon2id encrypted local vault for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context ☆`1`
 ### Network & Firewall
 
 - [vespo92/OPNSenseMCP](https://github.com/vespo92/OPNSenseMCP) — MCP Server for OPNSense to act as IaC proxy ☆`45`

--- a/README.md
+++ b/README.md
@@ -1551,6 +1551,7 @@
 - [AIM-Intelligence/AIM-MCP](https://github.com/AIM-Intelligence/AIM-MCP) — AIM MCP Server :: Guard and Protect your MCPs & AI Chatting ☆`20`
 - [cromwellian/hippycampus](https://github.com/cromwellian/hippycampus) — REST endpoint to MCP conversion ☆`20`
 - [kontext-security/attestable-mcp-server](https://github.com/kontext-security/attestable-mcp-server) — Hardware attestation for MCP server integrity ☆`18`
+- [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) — AES-256-GCM + Argon2id encrypted local vault for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context ☆`1`
 ### Network & Firewall
 
 - [vespo92/OPNSenseMCP](https://github.com/vespo92/OPNSenseMCP) — MCP Server for OPNSense to act as IaC proxy ☆`45`

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2921,6 +2921,8 @@ categories:
             description: Descope user management and audits
           - url: https://github.com/kanad13/MCP-Server-for-Hashing
           - url: https://github.com/Horizon-Digital-Engineering/fpe-demo-mcp
+          - url: https://github.com/Agnuxo1/enigmagent-mcp
+            description: Encrypted local vault for AI agents — resolve {{SECRET}} placeholders at runtime with AES-256-GCM + Argon2id. LLMs never see real API keys.
       - name: MCP Security
         repos:
           - url: https://github.com/82ch/MCP-Dandan


### PR DESCRIPTION
Adding [Agnuxo1/enigmagent-mcp](https://github.com/Agnuxo1/enigmagent-mcp) to the **Security → Identity & Access** subcategory in `repositories.yaml`.

**enigmagent-mcp** is a local AES-256-GCM + Argon2id encrypted vault MCP server. AI agents resolve `{{SECRET}}` placeholders at runtime — LLMs never see real API keys.

- `npx enigmagent-mcp` — zero install, works on Windows/macOS/Linux
- MIT licensed, zero cloud, zero telemetry
- npm: `enigmagent-mcp` (published)

Changes: only `repositories.yaml` modified (README.md left unchanged, as per contribution guidelines).