### PR TITLE
Add prompt-to-asset: unified image generation MCP server (30+ models)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2210,6 +2210,8 @@ categories:
             description: Image and video generation with WaveSpeed AI
           - url: https://github.com/SureScaleAI/openai-gpt-image-mcp
             description: OpenAI GPT-4o image generation and editing
+          - url: https://github.com/MohamedAbdallah-14/prompt-to-asset
+            description: Image generation across 30+ models (DALL-E, Flux, Stable Diffusion, Midjourney) via unified API
       - name: Image Processing
         repos:
           - url: https://github.com/stass/exif-mcp


### PR DESCRIPTION
Add [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) to the Image Generation section.

**What it does:** MCP server routing image generation prompts across 30+ models (DALL-E, Flux, Stable Diffusion, Midjourney, and more) via a unified API.

**Install:** `npm install -g prompt-to-asset`

Unlike single-model MCP servers, prompt-to-asset is a model-agnostic router — one tool, any provider.