### PR TITLE
Add Beever Atlas to AI Memory & RAG > Memory

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -120,6 +120,8 @@ categories:
           - url: https://github.com/Smart-AI-Memory/empathy-framework
           - url: https://github.com/unibaseio/membase-mcp
             description: Decentralized memory layer for AI agents
+          - url: https://github.com/Beever-AI/beever-atlas
+            description: LLM Wiki memory for team chat (Slack, Discord, Teams)
       - name: RAG
         repos:
           - url: https://github.com/apecloud/ApeRAG


### PR DESCRIPTION
## What

Adds [Beever Atlas](https://github.com/Beever-AI/beever-atlas) to `AI Memory & RAG → Memory`.

## Why this fits

Beever Atlas is an open-source LLM Wiki for team chat — a 16-tool MCP server that exposes distilled team-conversation memory (from Slack, Discord, Microsoft Teams, Mattermost, Telegram) to clients like Claude Code and Cursor. Apache 2.0, runnable in 3 commands (`make demo`).

Sits naturally next to existing `Memory` entries:

- `CheMiguel23/MemoryMesh` — MCP server for knowledge graph memory
- `knowall-ai/mcp-neo4j-agent-memory` — Memory management using graph DB
- `unibaseio/membase-mcp` — Decentralized memory layer

Distinct angle: chat-corpus-specific extraction pipeline + 3-tier semantic schema + entity graph, exposed as MCP tools.

## Quality criteria

- GitHub-only ✓
- Active: released April 19, 2026, daily commits, open issues triaged
- Quality: 87 stars / 12 forks within first week; full docs at https://docs.beever.ai/atlas
- Relevant: MCP server with 16 tools

## Disclosure

I'm a maintainer of Beever Atlas (Beever AI Limited, Toronto).