### PR TITLE
Add Parsegl/parse-mcp to Marketing & Analytics

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2104,6 +2104,8 @@ categories:
       - url: https://github.com/MarketplaceAdPros/amazon-ads-mcp-server
       - url: https://github.com/open-strategy-partners/osp_marketing_tools
         description: MCP server for marketing automation tools
+      - url: https://github.com/Parsegl/parse-mcp
+        description: Look up how any brand surfaces in ChatGPT and Google AI Overviews
       - url: https://github.com/pipeboard-co/meta-ads-mcp
       - url: https://github.com/stape-io/stape-mcp-server
       - url: https://github.com/stape-io/google-tag-manager-mcp-server


### PR DESCRIPTION
Adds the Parse MCP server to the **Marketing & Analytics** category in `repositories.yaml` (alphabetically between `open-strategy-partners` and `pipeboard-co`).

Parse is a hosted MCP server (HTTP transport, no auth) that exposes a public AI brand visibility index. It lets any MCP-capable client look up how brands surface in ChatGPT and Google AI Overviews via four primary tools (`parse_search`, `parse_get_brand`, `parse_get_prompt`, `parse_get_stats`). 577,000+ brands tracked.

Repo: https://github.com/Parsegl/parse-mcp
Live endpoint: https://mcp.parse.gl/mcp

Followed CONTRIBUTING.md: edited `repositories.yaml` only, README will regenerate on the next daily rebuild.