### PR TITLE
feat: add KubeStellar Console kc-agent to Kubernetes section

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -559,6 +559,8 @@ categories:
           - url: https://github.com/vfarcic/dot-ai
             description: Deploy apps to any Kubernetes cluster
           - url: https://github.com/kubesphere/ks-mcp-server
+          - url: https://github.com/kubestellar/console
+            description: AI-powered multi-cluster Kubernetes dashboard with MCP server (kc-agent) for natural language operations
       - name: Virtualization & IaC
         repos:
           - url: https://github.com/bright8192/esxi-mcp-server


### PR DESCRIPTION
Adds **[KubeStellar Console kc-agent](https://github.com/kubestellar/console)** to the Kubernetes section.

The kc-agent is the MCP server component of KubeStellar Console:
- MCP server that bridges AI assistants (Claude, Copilot, Cursor) to live Kubernetes clusters
- Natural language multi-cluster operations: query health, manage workloads, orchestrate deployments
- Real-time observability across edge and cloud clusters
- CNCF Sandbox project (Apache 2.0)

**Repository:** https://github.com/kubestellar/console
**Stars:** 350+