### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2148,6 +2148,8 @@ categories:
       - url: https://github.com/gvaibhav/TAM-MCP-Server
         description: Market sizing and TAM/SAM analysis
       - url: https://github.com/amekala/ads-mcp
+      - url: https://github.com/nowork-studio/toprank
+        description: NotFair Google Ads MCP — diagnose, recommend, and execute campaign changes
   - name: Media Processing
     subcategories:
       - name: 3D & Animation


### PR DESCRIPTION
Adding NotFair under Marketing & Analytics in repositories.yaml. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Following the README's note that the list is rebuilt daily from repositories.yaml.