### PR TITLE
Add HelpCode-ai/anythingmcp under Aggregators & Gateways > Gateways & Proxies

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -233,6 +233,8 @@ categories:
             description: Coordinate agents using rooms
       - name: Gateways & Proxies
         repos:
+          - url: https://github.com/HelpCode-ai/anythingmcp
+            description: Self-hosted source-available MCP gateway converting REST/SOAP/GraphQL/SQL APIs into MCP tools with 29 pre-built adapters and OAuth2 + RBAC + audit log
           - url: https://github.com/sxhxliang/mcp-access-point
             description: Convert any web server to MCP instantly
           - url: https://github.com/tigranbs/mcgravity


### PR DESCRIPTION
Adds [HelpCode-ai/anythingmcp](https://github.com/HelpCode-ai/anythingmcp) to \`Aggregators & Gateways > Gateways & Proxies\`.

**What it is:** a self-hosted, source-available MCP gateway and API-to-MCP bridge. Converts REST, SOAP/WSDL, GraphQL endpoints and SQL/NoSQL databases (PostgreSQL, MySQL, MariaDB, MSSQL, Oracle, MongoDB, SQLite) into MCP tools. Ships with 29 pre-built adapters and built-in OAuth2 / RBAC / audit log.

**Repo:** https://github.com/HelpCode-ai/anythingmcp
**Website:** https://anythingmcp.com
**License:** BSL-1.1 (source-available, converts to Apache 2.0 on 2030-03-04).

YAML entry validated against the schema referenced in \`repositories.yaml\` (single URL with description, placed first under \`Gateways & Proxies\`).

Disclosure: I am the author/maintainer.