### PR TITLE
Add Martin Loop to code assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 - [CodeGraphContext/CodeGraphContext](https://github.com/CodeGraphContext/CodeGraphContext) — Code graph indexing for AI context ☆`3,329`
 - [ezyang/codemcp](https://github.com/ezyang/codemcp) — Coding assistant MCP for Claude Desktop ☆`1,615`
 - [ref-tools/ref-tools-mcp](https://github.com/ref-tools/ref-tools-mcp) — Reference tools for coding agents ☆`1,103`
+- [Keesan12/martin-loop](https://github.com/Keesan12/martin-loop/tree/main/packages/mcp) — Governed runtime for coding agents with budget caps, verifier gates, and inspectable runs ☆`15`
 - [SDGLBL/mcp-claude-code](https://github.com/SDGLBL/mcp-claude-code) — MCP implementation of Claude Code capabilities and more ☆`301`
 - [stippi/code-assistant](https://github.com/stippi/code-assistant) — LLM-powered autonomous coding assistant ☆`163`
 - [lamemind/mcp-server-multiverse](https://github.com/lamemind/mcp-server-multiverse) — MCP server for multiverse context management ☆`77`


### PR DESCRIPTION
Adds Martin Loop to the code assistants section. Martin Loop provides a governed runtime layer for coding agents with budget caps, verifier gates, and inspectable runs.