### PR TITLE
feat: add Longbridge MCP (official brokerage, Finance > Trading & Exchanges)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1872,6 +1872,8 @@ categories:
             description: QuantConnect trading orchestration
           - url: https://github.com/solangii/upbit-mcp-server
           - url: https://github.com/memetus/okx-mcp-playground
+          - url: https://github.com/longbridge/longbridge-mcp
+            description: Official Longbridge brokerage MCP — 133 tools for US/HK real-time quotes, options, trading, fundamentals, IPO, alerts, DCA & portfolio. OAuth 2.1.
   - name: Frameworks & SDKs
     repos:
       - url: https://github.com/ECF/MCPToolGroups


### PR DESCRIPTION
## Add Longbridge MCP

**Repository:** https://github.com/longbridge/longbridge-mcp  
**Section:** Finance > Trading & Exchanges  

### Description

Official MCP server from Longbridge Securities — a licensed brokerage. Provides **133 tools** covering:

- Real-time quotes for US / HK / A-share / Singapore markets
- Options chains, warrants, derivatives
- Live trading: order placement, positions, portfolio management
- Fundamentals: financials, earnings, analyst ratings
- IPO calendar, corporate events, price alerts
- DCA strategies, portfolio analysis

**Remote endpoint:** `https://openapi.longbridge.com/mcp` (Streamable HTTP)  
**Auth:** OAuth 2.1 (RFC 9728)  

### Changes

- Added entry to `repositories.yaml` under `Finance > Trading & Exchanges`
- Follows existing entry format (url + description)