### PR TITLE
feat: add Gapup MCP (183 agent-payable C-suite tools)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -3038,6 +3038,10 @@ categories:
           - url: https://github.com/Contrast-Security-OSS/mcp-contrast
           - url: https://github.com/safedep/pinner-mcp
           - url: https://github.com/Program-Integrity-Alliance/pia-mcp-local
+      - name: Compliance & Regulatory
+        repos:
+          - url: https://github.com/getgapup/gapup-mcp
+            description: 175-tool gold-standard MCP server covering EU AI Act, GDPR, 6-source sanctions (OFAC/UN/EU/UK/SECO/AUSTRAC), KYC/AML, trade compliance, and financial models. Remote HTTP at mcp.gapup.io.
   - name: Social Media
     repos:
       - url: https://github.com/anwerj/youtube-uploader-mcp

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -3040,8 +3040,8 @@ categories:
           - url: https://github.com/Program-Integrity-Alliance/pia-mcp-local
       - name: Compliance & Regulatory
         repos:
-          - url: https://github.com/getgapup/gapup-mcp
-            description: 175-tool gold-standard MCP server covering EU AI Act, GDPR, 6-source sanctions (OFAC/UN/EU/UK/SECO/AUSTRAC), KYC/AML, trade compliance, and financial models. Remote HTTP at mcp.gapup.io.
+          - url: https://github.com/getgapup/gapup-mcp-public
+            description: "100+ agent-payable C-suite expertises in one MCP — competitive intel (EDGAR+Yahoo+Wayback), SEC filing decoder, 8-list sanctions screener (OFAC+EU+UK+UN+SECO+SEMA+DFAT), KYC, pentest scope, clinical evidence GRADE-graded (PubMed+ClinicalTrials.gov+OpenFDA), EU-first real estate, NAICS classifier, sentiment news (GDELT), research paper Q&A (OpenAlex 45M). 183 tools. x402 USDC/EURC. Free 100 calls/mo."
   - name: Social Media
     repos:
       - url: https://github.com/anwerj/youtube-uploader-mcp


### PR DESCRIPTION
## Description

Adds Gapup MCP in a new `Compliance & Regulatory` subcategory under the Security category in `repositories.yaml`.

## What is Gapup MCP?

Gapup MCP is a remote MCP server with 183 tools covering C-suite intelligence verticals:

- Competitive intel (EDGAR + Yahoo Finance + Wayback Machine)
- SEC filing decoder
- 8-list sanctions screener (OFAC + EU + UK + UN + SECO + SEMA + DFAT)
- KYC / entity verification
- Pentest scope builder (attack surface)
- Clinical evidence GRADE-graded (PubMed + ClinicalTrials.gov + OpenFDA)
- EU-first real estate (DVF Cerema + Géorisques)
- NAICS classifier, sentiment news (GDELT), research paper Q&A (OpenAlex 45M)

**183 tools. Pay-per-call x402 USDC/EURC on Base+Optimism. Free 100 calls/mo.**

- GitHub: https://github.com/getgapup/gapup-mcp-public
- MCP endpoint: https://mcp.gapup.io/mcp
- Smithery (verified ✓): https://smithery.ai/servers/gapup-team/gapup-mcp

## Checklist

- [x] Only `repositories.yaml` modified
- [x] Format matches existing YAML conventions