### PR TITLE
Add brewpage-mcp to File Systems & Storage

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1623,6 +1623,8 @@ categories:
       - url: https://github.com/vespo92/TrueNasCoreMCP
       - url: https://github.com/CyberhavenInc/filesystem-mcpignore
       - url: https://github.com/flesler/mcp-files
+      - url: https://github.com/kochetkov-ma/brewpage-openapi
+        description: Free HTML/Markdown/KV/JSON/file hosting at brewpage.app (no signup)
   - name: Finance
     subcategories:
       - name: Accounting & Budgeting


### PR DESCRIPTION
Adds [brewpage-mcp](https://github.com/kochetkov-ma/brewpage-openapi) to the **File Systems & Storage** section.

BrewPage (`https://brewpage.app`) is a free, MIT-licensed HTML/Markdown/KV/JSON/file hosting platform with short URLs and no signup. The MCP server lets agents publish content to a public REST API, manage owner-tokened resources, retrieve pages, and read platform stats.

- npm: [`brewpage-mcp`](https://www.npmjs.com/package/brewpage-mcp) (current v1.5.1)
- Official MCP Registry: `io.github.kochetkov-ma/brewpage-mcp`
- Tools: 14 (publish/update/delete HTML, KV, JSON, files, multi-file sites; get_page; get_stats; gallery search)
- Docs: https://kochetkov-ma.github.io/brewpage-openapi/
- OpenAPI 3.1: https://kochetkov-ma.github.io/brewpage-openapi/openapi.json

Entry added at the end of File Systems & Storage section per current ordering convention.