### PR TITLE
Add ejentum-mcp to AI Agents > Reasoning & Prompts

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -74,6 +74,8 @@ categories:
           - url: https://github.com/wn01011/llm-token-tracker
           - url: https://github.com/abhinav-mangla/inner-monologue-mcp
           - url: https://github.com/abhinav-mangla/think-tool-mcp
+          - url: https://github.com/ejentum/ejentum-mcp
+            description: Reasoning harness exposing four agentic tools (reasoning, code, anti-deception, memory) the agent calls during its loop
   - name: AI Memory & RAG
     subcategories:
       - name: Memory


### PR DESCRIPTION
Adds `ejentum-mcp` to `repositories.yaml` under **AI Agents → Reasoning & Prompts** (alphabetically alongside think-tool-mcp, inner-monologue-mcp, etc.).

`ejentum-mcp` is a pre-generation reasoning harness MCP server. Four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`) return structured cognitive scaffolds (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads before producing its user-facing answer.

- npm: https://www.npmjs.com/package/ejentum-mcp (v0.1.x with OIDC provenance)
- Hosted: https://api.ejentum.com/mcp (Streamable HTTP)
- Source: https://github.com/ejentum/ejentum-mcp
- Twelve native framework integrations on PyPI/npm (CrewAI, Agno, PydanticAI, smolagents on PyPI; ejentum-ai, ejentum-mastra, ejentum-langgraph, ejentum-genkit on npm)
- License: MIT

YAML syntax verified clean with PyYAML.