### PR TITLE
Update Hive Intelligence source repo

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1674,7 +1674,8 @@ categories:
           - url: https://github.com/getalby/nwc-mcp-server
           - url: https://github.com/heurist-network/heurist-mesh-mcp-server
             description: Blockchain and web3 via Heurist Mesh
-          - url: https://github.com/hive-intel/hive-crypto-mcp
+          - url: https://github.com/hive-intel/hive-sdk
+            description: Managed crypto intelligence MCP for AI agents across market data, DeFi, wallets, security, DEX flows, NFTs, Solana, infrastructure, and prediction markets.
           - url: https://github.com/JamesANZ/bitcoin-mcp
           - url: https://github.com/JamesANZ/evm-mcp
           - url: https://github.com/janswist/mcp-dexscreener


### PR DESCRIPTION
**Summary**
- Update Hive Intelligence from the deprecated `hive-crypto-mcp` source URL to the canonical `hive-sdk` repository.
- Add a concise current description so generated README metadata no longer depends on stale redirect-derived copy.

**Verification**
- `ruby -e 'require "yaml"; YAML.load_file("repositories.yaml"); puts "yaml ok"'`\n- `git diff --check`\n\n**Mark the following tasks as done:**\n- [x] Checked `repositories.yaml` to ensure that your repository is not already listed.\n- [x] Checked the pull requests to ensure that another person has not already submitted the same repository.\n- [x] Take note of the [contributing guidelines](https://github.com/abordage/awesome-mcp/blob/main/.github/CONTRIBUTING.md).\n- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).\n- [x] Repository being added is actively maintained (recent commits).\n- [x] Repository being added has an open source license.\n\n### Thanks for contributing!