### PR TITLE
Add MCP Doctor to MCP Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,6 +1573,8 @@
 - [kontext-security/attestable-mcp-server](https://github.com/kontext-security/attestable-mcp-server) — Hardware attestation for MCP server integrity ☆`18`
 - [AIM-Intelligence/AIM-MCP](https://github.com/AIM-Intelligence/AIM-MCP) — AIM MCP Server :: Guard and Protect your MCPs & AI Chatting ☆`20`
 - [cromwellian/hippycampus](https://github.com/cromwellian/hippycampus) — REST endpoint to MCP conversion ☆`20`
+- [xlyoung/mcp-doctor](https://github.com/xlyoung/mcp-doctor) — Scan, score, and install MCP servers with security checks ☆`0`
+
 ### Network & Firewall
 
 - [vespo92/OPNSenseMCP](https://github.com/vespo92/OPNSenseMCP) — MCP Server for OPNSense to act as IaC proxy ☆`54`


### PR DESCRIPTION
Hi! I'd like to add [MCP Doctor](https://github.com/xlyoung/mcp-doctor) to the MCP Security section.

**MCP Doctor** is a CLI tool that combines security scanning, quality scoring (0-100), and a curated registry of 100+ MCP servers into a single toolkit. It helps developers vet MCP servers before installing them.

**Key features:**
- 8 security detection engines (prompt injection, path traversal, credential leakage, SSRF, etc.)
- Automated quality scoring across 5 dimensions
- Side-by-side server comparison
- One-command install with security gating
- CI/CD integration with exit codes

Added at the end of the MCP Security section, sorted by star count.

Thanks for maintaining this awesome list!