### PR TITLE
Add Unstoppable Domains MCP server

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2794,6 +2794,8 @@ categories:
           - url: https://github.com/shopsavvy/shopsavvy-mcp-server
           - url: https://github.com/siva010928/multi-chat-mcp-server
             description: MCP server for multi-chat capabilities
+          - url: https://github.com/unstoppabledomains/unstoppable-mcp-server
+            description: Domain search, registration, DNS, marketplace, and checkout
           - url: https://github.com/urlbox/urlbox-mcp-server
           - url: https://github.com/yamanoku/baseline-mcp-server
             description: Web API Baseline status information


### PR DESCRIPTION
Adds the official Unstoppable Domains MCP server under `Search & Extraction > Data APIs`, alongside the existing `imprvhub/mcp-domain-availability` entry.

- **Repo:** https://github.com/unstoppabledomains/unstoppable-mcp-server
- **Endpoint:** https://api.unstoppabledomains.com/mcp/v1/ (Streamable HTTP, OAuth 2.0)
- **Registry:** [`com.unstoppabledomains/mcp-server`](https://registry.modelcontextprotocol.io/v0/servers?search=unstoppabledomains) (Official MCP Registry, DNS-verified namespace)
- **License:** MIT, vendor-maintained
- **Tools:** 60 (domain search, DNS management, marketplace listings, cart/checkout, AI landing pages, portfolio operations)

Inserted alphabetically by repo URL between `siva010928/multi-chat-mcp-server` and `urlbox/urlbox-mcp-server`. Single 2-line YAML addition to `repositories.yaml` — README will regenerate automatically on next daily build.

If you'd prefer a different category (e.g. a new `Domains` subcategory, or `Cloud & Infrastructure`), happy to amend.