### PR TITLE
feat: add Disentinel/grafema — code graph MCP server

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1190,6 +1190,8 @@ categories:
           - url: https://github.com/micl2e2/code-to-tree
             description: Source code to AST tree conversion
           - url: https://github.com/vezlo/src-to-kb
+          - url: https://github.com/Disentinel/grafema
+            description: Semantic code graph MCP server for AI coding agents — 40+ tools for call-chain tracing, data-flow analysis, and semantic code search
       - name: Debuggers
         repos:
           - url: https://github.com/cameroncooke/reloaderoo


### PR DESCRIPTION
## What

Adds [Grafema](https://github.com/Disentinel/grafema) to the **Developer Tools > Code Analysis** section.

## About Grafema

Grafema is a semantic code graph MCP server for AI coding agents. It indexes a codebase into a typed graph and exposes 40+ MCP tools for call-chain tracing, data-flow analysis, semantic search, and invariant checking — so agents navigate structure instead of reading files line by line.

- **npm**: `npm install -g grafema`
- **Transport**: stdio
- **License**: FSL-1.1-Apache-2.0
- **Platforms**: macOS (arm64/x64), Linux (arm64/x64)
- **GitHub**: https://github.com/Disentinel/grafema

## Change

Added one entry to `repositories.yaml` under `Developer Tools > Code Analysis`:

```yaml
- url: https://github.com/Disentinel/grafema
  description: Semantic code graph MCP server for AI coding agents — 40+ tools for call-chain tracing, data-flow analysis, and semantic code search
```