### PR TITLE
feat: add NotFair — Claude Code skills for SEO and paid ads

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2171,6 +2171,8 @@ categories:
       - url: https://github.com/amekala/ads-mcp
       - url: https://github.com/nowork-studio/toprank
         description: NotFair Google Ads MCP — diagnose, recommend, and execute campaign changes
+      - url: https://github.com/nowork-studio/NotFair
+        description: Claude Code skills for SEO, GEO, Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP
   - name: Media Processing
     subcategories:
       - name: 3D & Animation


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource for the MCP community.

I'd like to suggest adding [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills for marketing work (~2.9k stars, MIT license). It covers SEO/GEO analysis, keyword research, meta tags, schema markup, Google Ads audits, and Meta Ads optimization. Each skill area connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

It fits naturally in the **Marketing & Analytics** section alongside the other ads and SEO-related entries.

Happy to adjust the description, wording, or placement if anything doesn't match your formatting conventions. Thanks for considering it!