### PR TITLE
Add mnemoverse/mcp-memory-server to AI Memory & RAG > Memory

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -124,6 +124,8 @@ categories:
             description: Decentralized memory layer for AI agents
           - url: https://github.com/Beever-AI/beever-atlas
             description: LLM Wiki memory for team chat (Slack, Discord, Teams)
+          - url: https://github.com/mnemoverse/mcp-memory-server
+            description: Hosted memory that reranks and fades by recency
       - name: RAG
         repos:
           - url: https://github.com/apecloud/ApeRAG


### PR DESCRIPTION
Adds the open MIT MCP server for Mnemoverse, a hosted persistent-memory API for AI agents (write a fact once, recall it across Claude, Cursor, VS Code, and ChatGPT via MCP). Listed under **AI Memory & RAG > Memory**.

- Repo: https://github.com/mnemoverse/mcp-memory-server (MIT)
- npm: `@mnemoverse/mcp-memory-server` (`npx -y @mnemoverse/mcp-memory-server@latest`, stdio)
- Site: https://mnemoverse.com

Only `repositories.yaml` is edited; stars/ranking are left to the daily pipeline.
