### PR TITLE
Add kaitoInfra/twitterapi-io-mcp-server (Social Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1633,6 +1633,7 @@
 - [trypeggy/instagram_dm_mcp](https://github.com/trypeggy/instagram_dm_mcp) — Instagram Direct messages MCP ☆`173`
 - [king-of-the-grackles/reddit-research-mcp](https://github.com/king-of-the-grackles/reddit-research-mcp) — Reddit research with structured insights ☆`126`
 - [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) — X/Twitter API platform with MCP, tweet search, profile tweets, follower export, media download, posting, replies, webhooks, REST API, and SDKs ☆`116`
+- [kaitoInfra/twitterapi-io-mcp-server](https://github.com/kaitoInfra/twitterapi-io-mcp-server) — Hosted MCP server for [twitterapi.io](https://twitterapi.io), a Twitter/X data API for AI agents. 12 read-only tools: tweet search with full operators, profiles, threads, real-time WebSocket streaming, trending topics. Hosted endpoint at `mcp.twitterapi.io/mcp` ☆`0`
 - [LuniaKunal/mcp-twitter](https://github.com/LuniaKunal/mcp-twitter) — Manage your twitter account using mcp ☆`59`
 - [ertiqah/linkedin-mcp-runner](https://github.com/ertiqah/linkedin-mcp-runner) — LinkedIn content analysis and posting ☆`30`
 - [anwerj/youtube-uploader-mcp](https://github.com/anwerj/youtube-uploader-mcp) — Upload/Schedule videos on Youtube with the help of AI ☆`40`

--- a/README.md
+++ b/README.md
@@ -1633,7 +1633,6 @@
 - [trypeggy/instagram_dm_mcp](https://github.com/trypeggy/instagram_dm_mcp) — Instagram Direct messages MCP ☆`173`
 - [king-of-the-grackles/reddit-research-mcp](https://github.com/king-of-the-grackles/reddit-research-mcp) — Reddit research with structured insights ☆`126`
 - [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) — X/Twitter API platform with MCP, tweet search, profile tweets, follower export, media download, posting, replies, webhooks, REST API, and SDKs ☆`116`
-- [kaitoInfra/twitterapi-io-mcp-server](https://github.com/kaitoInfra/twitterapi-io-mcp-server) — Hosted MCP server for [twitterapi.io](https://twitterapi.io), a Twitter/X data API for AI agents. 12 read-only tools: tweet search with full operators, profiles, threads, real-time WebSocket streaming, trending topics. Hosted endpoint at `mcp.twitterapi.io/mcp` ☆`0`
 - [LuniaKunal/mcp-twitter](https://github.com/LuniaKunal/mcp-twitter) — Manage your twitter account using mcp ☆`59`
 - [ertiqah/linkedin-mcp-runner](https://github.com/ertiqah/linkedin-mcp-runner) — LinkedIn content analysis and posting ☆`30`
 - [anwerj/youtube-uploader-mcp](https://github.com/anwerj/youtube-uploader-mcp) — Upload/Schedule videos on Youtube with the help of AI ☆`40`

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -3098,6 +3098,8 @@ categories:
         description: Bilibili video search MCP service
       - url: https://github.com/Xquik-dev/x-twitter-scraper
         description: X/Twitter API platform with MCP, tweet search, profile tweets, follower export, media download, posting, replies, webhooks, REST API, and SDKs
+      - url: https://github.com/kaitoInfra/twitterapi-io-mcp-server
+        description: Hosted MCP for twitterapi.io — Twitter/X data API for AI agents; 12 read-only tools (tweet search, profiles, threads, real-time streaming)
   - name: Sports
     repos:
       - url: https://github.com/guillochon/mlb-api-mcp


### PR DESCRIPTION
Adds **kaitoInfra/twitterapi-io-mcp-server** under Social Media.

- Repo: https://github.com/kaitoInfra/twitterapi-io-mcp-server (MIT)
- npm: `@kaitoinfra/twitterapi-io-mcp-server`
- Hosted endpoint: `https://mcp.twitterapi.io/mcp`
- MCP Registry: `io.github.kaitoInfra/twitterapi-io-mcp-server` (active since 2026-05-23)

Twitter / X data API for AI agents — 12 read-only tools: tweet search with full operators, profiles, threads, real-time WebSocket streaming, trending topics.
